### PR TITLE
fix: Access Token 만료 처리 개선

### DIFF
--- a/src/lib/auth/tokenStorage.ts
+++ b/src/lib/auth/tokenStorage.ts
@@ -29,6 +29,19 @@ export const tokenStorage = {
     }
   },
 
+  /**
+   * 만료 체크 없이 토큰 데이터를 가져옴 (초기화 및 갱신 로직용)
+   */
+  getRaw(): TokenData | null {
+    try {
+      const data = localStorage.getItem(TOKEN_KEY);
+      if (!data) return null;
+      return JSON.parse(data);
+    } catch {
+      return null;
+    }
+  },
+
   remove(): void {
     try {
       localStorage.removeItem(TOKEN_KEY);


### PR DESCRIPTION
- 초기화 시 만료된 토큰도 유지하여 자동 갱신 시도
- 프로필 조회 시 API에서 자동으로 토큰 갱신
- 401 에러만 토큰 제거, 일시적 네트워크 에러는 토큰 유지
- tokenStorage.getRaw() 메서드 추가