### PR TITLE
fix: 채팅 API 토큰 갱신 및 채팅 서버 URL 분리

### DIFF
--- a/src/lib/api/chat.ts
+++ b/src/lib/api/chat.ts
@@ -12,6 +12,8 @@ import type {
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api';
+const CHAT_API_BASE_URL =
+  process.env.NEXT_PUBLIC_CHAT_API_URL || 'http://localhost:8081/api';
 
 export interface CreateOrGetChatRoomResponse {
   code: string;
@@ -41,31 +43,36 @@ export async function createOrGetChatRoom(
   targetUserId: string,
   propertyId: number
 ): Promise<ChatRoom> {
+  await ensureValidToken();
   const res = await apiClient<CreateOrGetChatRoomResponse>(
-    '/chat/v3/direct-chat/rooms',
+    `${CHAT_API_BASE_URL}/chat/v3/direct-chat/rooms`,
     {
       method: 'POST',
       body: JSON.stringify({ targetUserId, propertyId }),
       requiresAuth: true,
+      skipTokenRefresh: true,
     }
   );
   return res.data;
 }
 
 export async function getChatRooms(): Promise<ChatRoomsResponse> {
+  await ensureValidToken();
   const res = await apiClient<ChatRoomsApiResponse>(
-    '/chat/v3/direct-chat/rooms',
+    `${CHAT_API_BASE_URL}/chat/v3/direct-chat/rooms`,
     {
       requiresAuth: true,
+      skipTokenRefresh: true,
     }
   );
   return res.data;
 }
 
 export async function getChatRoomDetail(roomId: string): Promise<ChatRoom> {
+  await ensureValidToken();
   const res = await apiClient<ChatRoomDetailApiResponse>(
-    `/chat/v3/direct-chat/rooms/${roomId}`,
-    { requiresAuth: true }
+    `${CHAT_API_BASE_URL}/chat/v3/direct-chat/rooms/${roomId}`,
+    { requiresAuth: true, skipTokenRefresh: true }
   );
   return res.data;
 }
@@ -75,11 +82,12 @@ export async function getChatMessages(
   before?: string,
   size = 20
 ): Promise<ChatMessagesResponse> {
+  await ensureValidToken();
   const params = new URLSearchParams({ size: String(size) });
   if (before) params.set('before', before);
   const res = await apiClient<ChatMessagesApiResponse>(
-    `/chat/v3/direct-chat/rooms/${roomId}/messages?${params.toString()}`,
-    { requiresAuth: true }
+    `${CHAT_API_BASE_URL}/chat/v3/direct-chat/rooms/${roomId}/messages?${params.toString()}`,
+    { requiresAuth: true, skipTokenRefresh: true }
   );
   return res.data;
 }
@@ -92,7 +100,7 @@ export async function getPresignedUrls(
     code: string;
     message: string;
     data: PresignedResponse;
-  }>('/chat/v3/direct-chat/files/presigned-urls', {
+  }>(`${CHAT_API_BASE_URL}/chat/v3/direct-chat/files/presigned-urls`, {
     method: 'POST',
     body: JSON.stringify({ roomId, files: fileItems }),
     requiresAuth: true,
@@ -107,7 +115,7 @@ export async function completeUpload(
     code: string;
     message: string;
     data: CompleteResponse;
-  }>('/chat/v3/direct-chat/files/complete', {
+  }>(`${CHAT_API_BASE_URL}/chat/v3/direct-chat/files/complete`, {
     method: 'POST',
     body: JSON.stringify({ fileAssetIds }),
     requiresAuth: true,

--- a/src/lib/chat/stompClient.ts
+++ b/src/lib/chat/stompClient.ts
@@ -1,11 +1,11 @@
 import { Client } from '@stomp/stompjs';
 import type { StompEvent } from '@/types/chat';
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api';
+const CHAT_API_BASE_URL =
+  process.env.NEXT_PUBLIC_CHAT_API_URL || 'http://localhost:8081/api';
 
 export function getWsUrl(): string {
-  return API_BASE_URL.replace(/^http/, 'ws') + '/chat/ws';
+  return CHAT_API_BASE_URL.replace(/^http/, 'ws') + '/chat/ws';
 }
 
 interface CreateStompClientParams {


### PR DESCRIPTION
- 채팅 API 호출 전 ensureValidToken() 호출로 토큰 만료 시 사전 갱신
- CHAT_API_BASE_URL을 NEXT_PUBLIC_CHAT_API_URL 환경변수로 분리 (8081 포트)
- skipTokenRefresh: true 적용으로 채팅 서버 401 시 로그아웃 방지
- stompClient WS URL을 채팅 서버 URL 기준으로 변경